### PR TITLE
Use latest HTTParty and Crack gems

### DIFF
--- a/bitly.gemspec
+++ b/bitly.gemspec
@@ -23,17 +23,17 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<crack>, [">= 0.1.4"])
-      s.add_runtime_dependency(%q<httparty>, [">= 0.5.2"])
+      s.add_runtime_dependency(%q<crack>, [">= 0.1.8"])
+      s.add_runtime_dependency(%q<httparty>, [">= 0.7.4"])
       s.add_runtime_dependency(%q<oauth2>, [">= 0.1.1"])
     else
-      s.add_dependency(%q<crack>, [">= 0.1.4"])
-      s.add_dependency(%q<httparty>, [">= 0.5.2"])
+      s.add_dependency(%q<crack>, [">= 0.1.8"])
+      s.add_dependency(%q<httparty>, [">= 0.7.4"])
       s.add_dependency(%q<oauth2>, [">= 0.1.1"])
     end
   else
-    s.add_dependency(%q<crack>, [">= 0.1.4"])
-    s.add_dependency(%q<httparty>, [">= 0.5.2"])
+    s.add_dependency(%q<crack>, [">= 0.1.8"])
+    s.add_dependency(%q<httparty>, [">= 0.7.4"])
     s.add_dependency(%q<oauth2>, [">= 0.1.1"])
   end
 end


### PR DESCRIPTION
Hi Phil,

I've forked and updated the gem dependencies within your gemspec because we get warnings when loading the bitly gem. Long story short crack v0.1.7 says it's version is actually 0.1.6 and HTTParty explicitly checks version numbers.

Ran `rake test` and everything passes. Just get a few deprecation warnings about API changes in v3 of bitly.

Had to manually install a load of development dependencies, echoe, fakeweb, mocha and flexmock. I can branch and add the development depencies to the gemspec if you want.

ATB,
James
