### PR TITLE
http_proxy support added

### DIFF
--- a/lib/bitly/utils.rb
+++ b/lib/bitly/utils.rb
@@ -1,4 +1,5 @@
 require 'cgi'
+require 'ostruct'
 
 module Bitly
   module Utils
@@ -40,10 +41,13 @@ module Bitly
       url.query << "&" + long_urls.map { |long_url| "longUrl=#{CGI.escape(long_url)}" }.join("&") unless long_urls.nil?
       url
     end
-    
+
     def get_result(request)
       begin
-        json = Net::HTTP.get(request)
+        # check for http_proxy and apply if found
+        proxy = ENV['http_proxy'] ? Addressable::URI.parse(ENV['http_proxy']) : OpenStruct.new
+        json = Net::HTTP::Proxy( proxy.host, proxy.port ).get(request)
+
         # puts json.inspect
         result = Crack::JSON.parse(json)
       rescue

--- a/lib/bitly/v3/client.rb
+++ b/lib/bitly/v3/client.rb
@@ -1,3 +1,5 @@
+require 'ostruct'
+
 module Bitly
   module V3
     # The client is the main part of this gem. You need to initialize the client with your
@@ -6,6 +8,10 @@ module Bitly
     class Client
       include HTTParty
       base_uri 'http://api.bit.ly/v3/'
+      
+      # check for http_proxy and apply if found 
+      proxy = ENV['http_proxy'] ? Addressable::URI.parse(ENV['http_proxy']) : OpenStruct.new 
+      http_proxy( proxy.host, proxy.port )
 
       # Requires a login and api key. Get yours from your account page at http://bit.ly/a/account
       def initialize(login, api_key)


### PR DESCRIPTION
I needed to use the Gem behind our company firewall, so here's a patch for http_proxy support. It has no user interface, and will use the http_proxy environment variable if it's available, otherwise it will carry on as normal.
