### PR TITLE
Fix for issue #12

### DIFF
--- a/lib/bitly/v3/client.rb
+++ b/lib/bitly/v3/client.rb
@@ -111,10 +111,10 @@ module Bitly
       private
 
       def arrayize(arg)
-        if input.is_a?(String)
-          [input] 
+        if arg.is_a?(String)
+          [arg] 
         else
-          input.dup
+          arg.dup
         end
       end
     


### PR DESCRIPTION
This patch will cause the Client lookup methods to create a dup of the array if they were called with an array argument, to avoid having mutations carried up into the caller context.
