### PR TITLE
Add timeout when calling bit.ly API

### DIFF
--- a/lib/bitly/client.rb
+++ b/lib/bitly/client.rb
@@ -6,9 +6,9 @@ module Bitly
   API_URL     = 'http://api.bit.ly/'
   API_VERSION = '2.0.1'
 
-  def self.new(login, api_key)
+  def self.new(login, api_key, timeout=nil)
     if @version == 3
-      Bitly::V3::Client.new(login, api_key)
+      Bitly::V3::Client.new(login, api_key, timeout)
     else
       Bitly::Client.new(login,api_key)
     end


### PR DESCRIPTION
Had some issues when bit.ly didn't respond in a timely manner so I added an optional and configurable timeout in seconds when calling their API.

Only added it for the version 3 API since version 2 is deprecated (and should not be used).

This commit fixes issue #23

Cheers,
