### PR TITLE
Add development dependencies to the gemspec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,5 +13,11 @@ Echoe.new('bitly', Bitly::VERSION) do |p|
     ['httparty', '>= 0.7.6'],
     ['oauth2', '>= 0.5.0', '< 0.9']
   ]
-  p.development_dependencies = []
+  p.development_dependencies = [
+    ['echoe'],
+    ['rake'],
+    ['shoulda'],
+    ['flexmock'],
+    ['fakeweb']
+  ]
 end

--- a/bitly.gemspec
+++ b/bitly.gemspec
@@ -26,14 +26,29 @@ Gem::Specification.new do |s|
       s.add_runtime_dependency(%q<crack>, [">= 0.1.4"])
       s.add_runtime_dependency(%q<httparty>, [">= 0.7.6"])
       s.add_runtime_dependency(%q<oauth2>, ["< 0.9", ">= 0.5.0"])
+      s.add_development_dependency(%q<echoe>, [">= 0"])
+      s.add_development_dependency(%q<rake>, [">= 0"])
+      s.add_development_dependency(%q<shoulda>, [">= 0"])
+      s.add_development_dependency(%q<flexmock>, [">= 0"])
+      s.add_development_dependency(%q<fakeweb>, [">= 0"])
     else
       s.add_dependency(%q<crack>, [">= 0.1.4"])
       s.add_dependency(%q<httparty>, [">= 0.7.6"])
       s.add_dependency(%q<oauth2>, ["< 0.9", ">= 0.5.0"])
+      s.add_dependency(%q<echoe>, [">= 0"])
+      s.add_dependency(%q<rake>, [">= 0"])
+      s.add_dependency(%q<shoulda>, [">= 0"])
+      s.add_dependency(%q<flexmock>, [">= 0"])
+      s.add_dependency(%q<fakeweb>, [">= 0"])
     end
   else
     s.add_dependency(%q<crack>, [">= 0.1.4"])
     s.add_dependency(%q<httparty>, [">= 0.7.6"])
     s.add_dependency(%q<oauth2>, ["< 0.9", ">= 0.5.0"])
+    s.add_dependency(%q<echoe>, [">= 0"])
+    s.add_dependency(%q<rake>, [">= 0"])
+    s.add_dependency(%q<shoulda>, [">= 0"])
+    s.add_dependency(%q<flexmock>, [">= 0"])
+    s.add_dependency(%q<fakeweb>, [">= 0"])
   end
 end


### PR DESCRIPTION
This PR adds development dependencies to the gemspec, so future contributors don't have to play whack-a-mole with adding dependencies.

You may want to consider in the future managing your gemspec by hand instead of using echoe. There is [no need to generate gemspecs](http://yehudakatz.com/2010/04/02/using-gemspecs-as-intended/) with alternative tools, and it makes dependency resolution a PITA when the Gemfile uses the gemspec as your source, but the gemspec is being generated by a tool that's not already in the gemspec. But, for now, this will suffice.
