### PR TITLE
Replace crack with multi_json

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ Echoe.new('bitly', Bitly::VERSION) do |p|
   p.author = "Phil Nash"
   p.email = "philnash@gmail.com"
   p.extra_deps = [
-    ['crack', '>= 0.1.4'],
+    ['multi_json', '~> 1.0'],
     ['httparty', '>= 0.7.6'],
     ['oauth2', '>= 0.5.0', '< 0.9']
   ]

--- a/bitly.gemspec
+++ b/bitly.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 1.2") if s.respond_to? :required_rubygems_version=
   s.authors = ["Phil Nash"]
-  s.date = "2013-01-15"
+  s.date = "2013-02-01"
   s.description = "Use the bit.ly API to shorten or expand URLs"
   s.email = "philnash@gmail.com"
   s.extra_rdoc_files = ["README.md", "lib/bitly.rb", "lib/bitly/client.rb", "lib/bitly/url.rb", "lib/bitly/utils.rb", "lib/bitly/v3.rb", "lib/bitly/v3/bitly.rb", "lib/bitly/v3/client.rb", "lib/bitly/v3/country.rb", "lib/bitly/v3/day.rb", "lib/bitly/v3/missing_url.rb", "lib/bitly/v3/oauth.rb", "lib/bitly/v3/realtime_link.rb", "lib/bitly/v3/referrer.rb", "lib/bitly/v3/url.rb", "lib/bitly/v3/user.rb", "lib/bitly/version.rb"]
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--line-numbers", "--inline-source", "--title", "Bitly", "--main", "README.md"]
   s.require_paths = ["lib"]
   s.rubyforge_project = "bitly"
-  s.rubygems_version = "1.8.11"
+  s.rubygems_version = "1.8.24"
   s.summary = "Use the bit.ly API to shorten or expand URLs"
   s.test_files = ["test/bitly/test_client.rb", "test/bitly/test_url.rb", "test/bitly/test_utils.rb", "test/test_helper.rb"]
 
@@ -23,16 +23,16 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<crack>, [">= 0.1.4"])
+      s.add_runtime_dependency(%q<multi_json>, ["~> 1.0"])
       s.add_runtime_dependency(%q<httparty>, [">= 0.7.6"])
       s.add_runtime_dependency(%q<oauth2>, ["< 0.9", ">= 0.5.0"])
     else
-      s.add_dependency(%q<crack>, [">= 0.1.4"])
+      s.add_dependency(%q<multi_json>, ["~> 1.0"])
       s.add_dependency(%q<httparty>, [">= 0.7.6"])
       s.add_dependency(%q<oauth2>, ["< 0.9", ">= 0.5.0"])
     end
   else
-    s.add_dependency(%q<crack>, [">= 0.1.4"])
+    s.add_dependency(%q<multi_json>, ["~> 1.0"])
     s.add_dependency(%q<httparty>, [">= 0.7.6"])
     s.add_dependency(%q<oauth2>, ["< 0.9", ">= 0.5.0"])
   end

--- a/lib/bitly.rb
+++ b/lib/bitly.rb
@@ -1,7 +1,6 @@
 $:.unshift File.dirname(__FILE__)
 
-require 'crack'
-
+require 'multi_json'
 require 'bitly/utils'
 require 'bitly/client'
 require 'bitly/url'

--- a/lib/bitly/utils.rb
+++ b/lib/bitly/utils.rb
@@ -45,8 +45,8 @@ module Bitly
       begin
         json = Net::HTTP.get(request)
         # puts json.inspect
-        result = Crack::JSON.parse(json)
-      rescue
+        result = MultiJson.load(json)
+      rescue MultiJson::DecodeError
         result = {'errorMessage' => 'JSON Parse Error(Bit.ly messed up)', 'errorCode' => 69, 'statusCode' => 'ERROR'}
       end
       if result['statusCode'] == "OK"


### PR DESCRIPTION
The crack gem uses an extracted copy of an outdated Rails JSON parser, which uses YAML as a backend. This is vulnerable to arbitrary code execution in certain contexts:

https://groups.google.com/forum/#!topic/rubyonrails-security/1h2DR63ViGo

While I admit it's highly unlikely that bit.ly API responses will contain malicious input, I would very much like to be able to use the bitly gem without needing to install an unsafe dependency. This patch replaces crack with multi_json, which intelligently selects from the locally available JSON backends, placing minimal constraints on client dependencies.

I wasn't sure if updating the gemspec was the right thing to do - I figured it was best on grounds of consistency. Apologies if not; I'm happy to amend as necessary.

Cheers (and thanks for providing this software!),
Simon
