### PR TITLE
Add support for generic OAuth2 access token in v3 API client

### DIFF
--- a/lib/bitly/client.rb
+++ b/lib/bitly/client.rb
@@ -7,7 +7,7 @@ module Bitly
   API_URL     = 'http://api.bit.ly/'
   API_VERSION = '2.0.1'
 
-  def self.new(login, api_key, timeout=nil)
+  def self.new(login, api_key = nil, timeout=nil)
     if @version == 3
       Bitly::V3::Client.new(login, api_key, timeout)
     else

--- a/lib/bitly/config.rb
+++ b/lib/bitly/config.rb
@@ -11,6 +11,9 @@ module Bitly
 
     attr_accessor *OPTION_KEYS
 
+    alias_method :access_token, :login
+    alias_method :access_token=, :login=
+
     def configure
       yield self
       self

--- a/lib/bitly/v3/client.rb
+++ b/lib/bitly/v3/client.rb
@@ -4,14 +4,29 @@ module Bitly
     # username and API key and then you will be able to use the client to perform
     # all the rest of the actions available through the API.
     class Client
+      API_URL_SSL = 'https://api-ssl.bitly.com/v3/'
       include HTTParty
       base_uri 'http://api.bitly.com/v3/'
 
-      # Requires a login and api key. Get yours from your account page at https://bitly.com/a/your_api_key
+      # Requires a generic OAuth2 access token or -deprecated- login and api key.
+      # http://dev.bitly.com/authentication.html#apikey
+      # Generic OAuth2 access token: https://bitly.com/a/oauth_apps
+      # ApiKey: Get yours from your account page at https://bitly.com/a/your_api_key
       # Visit your account at http://bit.ly/a/account
-      def initialize(login, api_key, timeout=nil)
-        @default_query_opts = { :login => login, :apiKey => api_key }
-        self.timeout = timeout
+      def initialize(*args)
+        args.compact!
+        self.timeout = args.last.is_a?(Fixnum) ? args.pop : nil
+        if args.count == 1
+          # Set generic OAuth2 access token and change base URI (use SSL)
+          @default_query_opts = { :access_token => args.first }
+          self.class.base_uri API_URL_SSL
+        else
+          # Deprecated ApiKey authentication
+          @default_query_opts = {
+            :login => args[0],
+            :apiKey => args[1]
+          }
+        end
       end
 
       # Validates a login and api key

--- a/test/bitly/test_client.rb
+++ b/test/bitly/test_client.rb
@@ -7,6 +7,11 @@ class TestClient < Test::Unit::TestCase
       assert_equal Bitly::Client, b.class
     end
 
+    should "create a new bitly client with generic OAuth2 access token" do
+      b = Bitly.new(access_token)
+      assert_equal Bitly::Client, b.class
+    end
+
     should "create a new bitly client and configure with a block" do
       Bitly.configure do |config|
         config.api_key = api_key

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,6 +27,9 @@ end
 def login
   'test_account'
 end
+def access_token
+  'test_access_token'
+end
 
 class Test::Unit::TestCase
   def teardown


### PR DESCRIPTION
ApiKey authentication is deprecated in favor of OAuth requsts.
http://dev.bitly.com/authentication.html#apikey

This commit attempts to extend the existing code base with the minimum to support the generic OAuth2 access token, tested it with basic actions like /v3/shorten
