### PR TITLE
Allow newer version of oauth gem. Fixes #44

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ Echoe.new('bitly', Bitly::VERSION) do |p|
   p.extra_deps = [
     ['multi_json', '~> 1.3'],
     ['httparty', '>= 0.7.6'],
-    ['oauth2', '>= 0.5.0', '< 0.9']
+    ['oauth2', '>= 0.5.0']
   ]
   p.development_dependencies = [
     ['echoe'],

--- a/bitly.gemspec
+++ b/bitly.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "bitly"
-  s.version = "0.9.0"
+  s.version = "0.9.1"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 1.2") if s.respond_to? :required_rubygems_version=
   s.authors = ["Phil Nash"]
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<multi_json>, ["~> 1.3"])
       s.add_runtime_dependency(%q<httparty>, [">= 0.7.6"])
-      s.add_runtime_dependency(%q<oauth2>, ["< 0.9", ">= 0.5.0"])
+      s.add_runtime_dependency(%q<oauth2>, [">= 0.5.0"])
       s.add_development_dependency(%q<echoe>, [">= 0"])
       s.add_development_dependency(%q<rake>, [">= 0"])
       s.add_development_dependency(%q<shoulda>, [">= 0"])
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
     else
       s.add_dependency(%q<multi_json>, ["~> 1.3"])
       s.add_dependency(%q<httparty>, [">= 0.7.6"])
-      s.add_dependency(%q<oauth2>, ["< 0.9", ">= 0.5.0"])
+      s.add_dependency(%q<oauth2>, [">= 0.5.0"])
       s.add_dependency(%q<echoe>, [">= 0"])
       s.add_dependency(%q<rake>, [">= 0"])
       s.add_dependency(%q<shoulda>, [">= 0"])
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
   else
     s.add_dependency(%q<multi_json>, ["~> 1.3"])
     s.add_dependency(%q<httparty>, [">= 0.7.6"])
-    s.add_dependency(%q<oauth2>, ["< 0.9", ">= 0.5.0"])
+    s.add_dependency(%q<oauth2>, [">= 0.5.0"])
     s.add_dependency(%q<echoe>, [">= 0"])
     s.add_dependency(%q<rake>, [">= 0"])
     s.add_dependency(%q<shoulda>, [">= 0"])

--- a/lib/bitly/version.rb
+++ b/lib/bitly/version.rb
@@ -1,3 +1,3 @@
 module Bitly
-  VERSION = '0.9.0'
+  VERSION = '0.9.1'
 end


### PR DESCRIPTION
This updates the gemspec and version to allow newer versions of the oauth gem to be used. This fixes the broken bundle when bitly gem is combined with omniauth-facebook, omniauth-soundcloud and others.
