### PR TITLE
Update oauth to 0.9.3

### DIFF
--- a/bitly.gemspec
+++ b/bitly.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<multi_json>, ["~> 1.3"])
       s.add_runtime_dependency(%q<httparty>, [">= 0.7.6"])
-      s.add_runtime_dependency(%q<oauth2>, ["< 0.9", ">= 0.5.0"])
+      s.add_runtime_dependency(%q<oauth2>, ["~> 0.9.3", ">= 0.5.0"])
       s.add_development_dependency(%q<echoe>, [">= 0"])
       s.add_development_dependency(%q<rake>, [">= 0"])
       s.add_development_dependency(%q<shoulda>, [">= 0"])


### PR DESCRIPTION
The application I'm working on has an oauth dependency for a later version, and running bundle install gave me a conflict with the already-installed version (0.9.3). I thought I'd send this pull request since all your tests passed with this change and upgrading oauth isn't a bad idea to begin with.

Thanks!
- Ilya
