### PR TITLE
don't explode when the URL returned from bitly doesn't exactly match the URL provided by the user

### DIFF
--- a/lib/bitly/client.rb
+++ b/lib/bitly/client.rb
@@ -48,7 +48,7 @@ module Bitly
       if input.is_a? String
         request = create_url("shorten", :longUrl => input, :history => (opts[:history] ? 1 : nil))
         result = get_result(request)
-        result = {:long_url => input}.merge result[input]
+        result = {:long_url => input}.merge result.values.first
         Bitly::Url.new(@login,@api_key,result)
       elsif input.is_a? Array
         request = create_url("shorten", :history => (opts[:history] ? 1 : nil))

--- a/test/bitly/test_client.rb
+++ b/test/bitly/test_client.rb
@@ -47,6 +47,11 @@ class TestClient < Test::Unit::TestCase
         should "save the long url" do
           assert_equal "http://cnn.com", @url.long_url
         end
+        should "not fail when passing empty query parameters" do
+          stub_get(/^http:\/\/api.bit.ly\/shorten\?.*longUrl=.*test.com.*$/,"failing_test.json")
+          @url = @bitly.shorten('http://test.com?q= ')
+          assert_equal 'http://test.com?q= ', @url.long_url
+        end
       end
       context "multiple links" do
         setup do

--- a/test/fixtures/failing_test.json
+++ b/test/fixtures/failing_test.json
@@ -1,0 +1,1 @@
+{"errorCode": 0, "errorMessage": "", "results": {"http://test.com?q=": {"userHash": "1hfFfW2", "shortKeywordUrl": "", "hash": "1hfFfW3", "shortCNAMEUrl": "http://share.bf.vu/1hfFfW2", "shortUrl": "http://share.bf.vu/1hfFfW2"}}, "statusCode": "OK"}


### PR DESCRIPTION
Currently, the gem will fail when the URL passed in to shorten doesn't exactly match the URL returned from the Bitly API.  An example of this is when a query parameter is passed in with a space as the value, Bitly's API will return it without the space included, causing the gem to throw an exception.
