### PR TITLE
Allow accessing the error message directy

### DIFF
--- a/lib/bitly/client.rb
+++ b/lib/bitly/client.rb
@@ -137,9 +137,10 @@ end
 
 class BitlyError < StandardError
   attr_reader :code
-  alias :msg :message
+  attr_reader :msg
   def initialize(msg, code)
     @code = code
+    @msg = msg
     super("#{msg} - '#{code}'")
   end
 end


### PR DESCRIPTION
Since there's no 1-1 mapping between Bit.ly's error codes and error messages, it's nice to be able to grab the error message as Bitly provides it, instead of having to parse the `msg - code` string.
