### PR TITLE
Add optional state param to OAuth2 authorize_url

### DIFF
--- a/bitly.gemspec
+++ b/bitly.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
       s.add_runtime_dependency(%q<oauth2>, ["< 2.0", ">= 0.5.0"])
       s.add_development_dependency(%q<echoe>, [">= 0"])
       s.add_development_dependency(%q<rake>, [">= 0"])
+      s.add_development_dependency(%q<activesupport>, ["~> 3.2"])
       s.add_development_dependency(%q<shoulda>, [">= 0"])
       s.add_development_dependency(%q<flexmock>, [">= 0"])
       s.add_development_dependency(%q<fakeweb>, [">= 0"])

--- a/lib/bitly/v3/oauth.rb
+++ b/lib/bitly/v3/oauth.rb
@@ -19,8 +19,10 @@ module Bitly
 
       # Get the url to redirect a user to, pass the url you want the user
       # to be redirected back to.
-      def authorize_url(redirect_url)
-        client.auth_code.authorize_url(:redirect_uri => redirect_url).gsub(/api-ssl\./,'')
+      def authorize_url(redirect_url, state=nil)
+        params = {:redirect_uri => redirect_url}
+        params[:state] = state if state
+        client.auth_code.authorize_url(params).gsub(/api-ssl\./,'')
       end
 
       # Get the access token. You must pass the exact same redirect_url passed

--- a/test/bitly/test_client.rb
+++ b/test/bitly/test_client.rb
@@ -22,6 +22,18 @@ class TestClient < Test::Unit::TestCase
       assert_equal api_key, b.api_key
       assert_equal login, b.login
     end
+
+    should "create a proper OAuth2 authorization url" do
+      client = Bitly::V3::OAuth.new('CLIENT_ID', 'CLIENT_SECRET')
+      url = client.authorize_url('http://www.example.com/oauth_callback')
+      assert_equal "https://bitly.com/oauth/authorize?client_id=CLIENT_ID&redirect_uri=http%3A%2F%2Fwww.example.com%2Foauth_callback&response_type=code", url
+    end
+
+    should "create a proper OAuth2 authorization url with a state parameter" do
+      client = Bitly::V3::OAuth.new('CLIENT_ID', 'CLIENT_SECRET')
+      url = client.authorize_url('http://www.example.com/oauth_callback', 'some_state')
+      assert_equal "https://bitly.com/oauth/authorize?client_id=CLIENT_ID&redirect_uri=http%3A%2F%2Fwww.example.com%2Foauth_callback&response_type=code&state=some_state", url
+    end
   end
   context "using the bitly client" do
     setup do


### PR DESCRIPTION
Adding the optional `state` parameter that is documented [here](http://dev.bitly.com/authentication.html) to the `authorize_url` method.