### PR TITLE
Update README with config username

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Bitly.use_api_version_3
 
 Bitly.configure do |config|
   config.api_version = 3
+  config.login = "USERNAME"
   config.access_token = "API_KEY"
 end
 ```


### PR DESCRIPTION
If we don't add `config.login` then Bitly will raise invalid error
