### PR TITLE
fix: fix obtaining clicks for not an bit.ly link

### DIFF
--- a/lib/bitly/v3/client.rb
+++ b/lib/bitly/v3/client.rb
@@ -156,7 +156,7 @@ module Bitly
       end
 
       def is_a_short_url?(input)
-        input.match(/^http:\/\//)
+        input.match(/^https?:\/\//)
       end
 
       def get_single_method(method, input)


### PR DESCRIPTION
Hi, @philnash

I have a link like `https://www.oreilly.com/ideas/how-to-build-analytic-products-in-an-age-when-data-privacy-has-become-critical` which is shortened by bitly to link like `https://oreil.ly/2G4Hob0`
So in that way I could not obtain clicks, because method `is_a_short_url?` does not work with 'https'

🔥 