### PR TITLE
Change all generic doubles to verifying instance_doubles in specs

### DIFF
--- a/spec/bitly/api/bitlink/clicks_summary_spec.rb
+++ b/spec/bitly/api/bitlink/clicks_summary_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Bitly::API::Bitlink::ClicksSummary do
-  let(:client) { double("client") }
+  let(:client) { instance_double(Bitly::API::Client) }
   let(:clicks_summary_data) {
     {
       "unit_reference"=>"2020-01-05T05:17:43+0000",

--- a/spec/bitly/api/bitlink/link_click_spec.rb
+++ b/spec/bitly/api/bitlink/link_click_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Bitly::API::Bitlink::LinkClick do
       body: links_list_data.to_json,
       headers: {}
     )
-    client = double("client")
+    client = instance_double(Bitly::API::Client)
     expect(client).to receive(:request)
       .with(path: "/bitlinks/#{bitlink_id}/clicks", params: {
         "units" => nil,

--- a/spec/bitly/api/bitlink_spec.rb
+++ b/spec/bitly/api/bitlink_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Bitly::API::Bitlink do
-  let(:client) { double("client") }
+  let(:client) { instance_double(Bitly::API::Client) }
   let(:bitlink_data) {
     {
       "created_at"=>"2020-01-02T23:51:47+0000",
@@ -194,7 +194,7 @@ RSpec.describe Bitly::API::Bitlink do
     end
 
     it "can fetch the clicks summary" do
-      clicks_summary = double("clicks_summary")
+      clicks_summary = instance_double(Bitly::API::Bitlink::ClicksSummary)
       expect(Bitly::API::Bitlink::ClicksSummary).to receive(:fetch)
         .with(client: client, bitlink: bitlink.id, unit: nil, units: nil, unit_reference: nil, size: nil)
         .and_return(clicks_summary)
@@ -202,7 +202,7 @@ RSpec.describe Bitly::API::Bitlink do
     end
 
     it "can fetch the link clicks" do
-      link_clicks = double("link_clicks")
+      link_clicks = instance_double(Bitly::API::Bitlink::LinkClick)
       expect(Bitly::API::Bitlink::LinkClick).to receive(:list)
         .with(client: client, bitlink: bitlink.id, unit: nil, units: nil, unit_reference: nil, size: nil)
         .and_return(link_clicks)

--- a/spec/bitly/api/bsd_spec.rb
+++ b/spec/bitly/api/bsd_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Bitly::API::BSD do
       body: { "bsds" => bsds }.to_json,
       headers: {}
     )
-    client = double("client")
+    client = instance_double(Bitly::API::Client)
     expect(client).to receive(:request)
       .with(path: "/bsds")
       .and_return(response)

--- a/spec/bitly/api/click_metric_spec.rb
+++ b/spec/bitly/api/click_metric_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Bitly::API::ClickMetric do
       body: click_metric_data_referring_networks.to_json,
       headers: {}
     )
-    client = double('client')
+    client = instance_double(Bitly::API::Client)
     expect(client).to receive(:request)
       .with(path: "/groups/#{group_guid}/referring_networks", params: {
         'units' => nil,
@@ -108,7 +108,7 @@ RSpec.describe Bitly::API::ClickMetric do
       body: click_metric_data_countries.to_json,
       headers: {}
     )
-    client = double('client')
+    client = instance_double(Bitly::API::Client)
     expect(client).to receive(:request)
       .with(path: "/groups/#{group_guid}/countries", params: {
         'units' => nil,
@@ -133,7 +133,7 @@ RSpec.describe Bitly::API::ClickMetric do
       body: click_metric_bitlink_referrers.to_json,
       headers: {}
     )
-    client = double('client')
+    client = instance_double(Bitly::API::Client)
     expect(client).to receive(:request)
       .with(path: "/bitlinks/#{bitlink}/referrers", params: {
         'units' => nil,
@@ -158,7 +158,7 @@ RSpec.describe Bitly::API::ClickMetric do
       body: click_metric_data_countries.to_json,
       headers: {}
     )
-    client = double('client')
+    client = instance_double(Bitly::API::Client)
     expect(client).to receive(:request)
       .with(path: "/bitlinks/#{bitlink}/countries", params: {
         'units' => nil,
@@ -183,7 +183,7 @@ RSpec.describe Bitly::API::ClickMetric do
       body: click_metric_bitlink_referring_domains.to_json,
       headers: {}
     )
-    client = double('client')
+    client = instance_double(Bitly::API::Client)
     expect(client).to receive(:request)
       .with(path: "/bitlinks/#{bitlink}/referring_domains", params: {
         'units' => nil,
@@ -208,7 +208,7 @@ RSpec.describe Bitly::API::ClickMetric do
       body: click_metric_bitlink_referrers_by_domain.to_json,
       headers: {}
     )
-    client = double('client')
+    client = instance_double(Bitly::API::Client)
     expect(client).to receive(:request)
       .with(path: "/bitlinks/#{bitlink}/referrers_by_domains", params: {
         'units' => nil,

--- a/spec/bitly/api/client_spec.rb
+++ b/spec/bitly/api/client_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Bitly::API::Client do
   let(:token) { "token" }
-  let(:http) { double("http") }
+  let(:http) { instance_double(Bitly::HTTP::Client) }
 
   describe "#new" do
     it "requires at least one argument" do
@@ -189,7 +189,7 @@ RSpec.describe Bitly::API::Client do
       end
 
       it "updates a bitlink" do
-        bitlink = double("bitlink")
+        bitlink = instance_double(Bitly::API::Bitlink)
         expect(bitlink).to receive(:update)
           .with(
             archived: nil,
@@ -248,7 +248,7 @@ RSpec.describe Bitly::API::Client do
       end
 
       it "updates a user" do
-        user = double("user")
+        user = instance_double(Bitly::API::User)
         expect(Bitly::API::User).to receive(:new).and_return(user)
         expect(user).to receive(:update)
           .with(
@@ -294,7 +294,7 @@ RSpec.describe Bitly::API::Client do
 
       it "updates a group's preferences" do
         domain_preference = "j.mp"
-        prefs = double("preferences")
+        prefs = instance_double(Bitly::API::Group::Preferences)
         expect(Bitly::API::Group::Preferences).to receive(:new)
           .with(data: { "group_guid" => group_guid }, client: client)
           .and_return(prefs)
@@ -304,7 +304,7 @@ RSpec.describe Bitly::API::Client do
       end
 
       it "updates a group" do
-        group = double("group")
+        group = instance_double(Bitly::API::Group)
         expect(Bitly::API::Group).to receive(:new)
           .with(data: { "guid" => group_guid }, client: client)
           .and_return(group)
@@ -314,7 +314,7 @@ RSpec.describe Bitly::API::Client do
       end
 
       it "deletes a group" do
-        group = double("group")
+        group = instance_double(Bitly::API::Group)
         expect(Bitly::API::Group).to receive(:new)
           .with(data: { "guid" => group_guid }, client: client)
           .and_return(group)

--- a/spec/bitly/api/group/preferences_spec.rb
+++ b/spec/bitly/api/group/preferences_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Bitly::API::Group::Preferences do
   }
 
   it "can be fetched with a client and a group guid" do
-    client = double("client")
+    client = instance_double(Bitly::API::Client)
     response = Bitly::HTTP::Response.new(
       status: "200",
       body: preference_data.to_json,
@@ -25,7 +25,7 @@ RSpec.describe Bitly::API::Group::Preferences do
   end
 
   describe "with preferences" do
-    let(:client) { double("client") }
+    let(:client) { instance_double(Bitly::API::Client) }
     let(:preference) { Bitly::API::Group::Preferences.new(client: client, data: preference_data) }
 
     it "can update preferences" do

--- a/spec/bitly/api/group_spec.rb
+++ b/spec/bitly/api/group_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Bitly::API::Group do
       body: { "groups" => [group_data] }.to_json,
       headers: {}
     )
-    client = double("client")
+    client = instance_double(Bitly::API::Client)
     expect(client).to receive(:request)
       .with(path: "/groups", params: { "organization_guid" => nil })
       .and_return(response)
@@ -40,7 +40,7 @@ RSpec.describe Bitly::API::Group do
       body: { "groups" => [group_data] }.to_json,
       headers: {}
     )
-    client = double("client")
+    client = instance_double(Bitly::API::Client)
     expect(client).to receive(:request)
       .with(path: "/groups", params: { "organization_guid" => "abc123" })
       .and_return(response)
@@ -56,7 +56,7 @@ RSpec.describe Bitly::API::Group do
       body: group_data.to_json,
       headers: {}
     )
-    client = double("client")
+    client = instance_double(Bitly::API::Client)
     expect(client).to receive(:request).with(path: "/groups/def456").and_return(response)
     group = Bitly::API::Group.fetch(client: client, group_guid: "def456")
     expect(group.name).to eq("philnash")
@@ -64,8 +64,8 @@ RSpec.describe Bitly::API::Group do
   end
 
   describe "with a group" do
-    let(:client) { double("client") }
-    let(:organization) { double("organization") }
+    let(:client) { instance_double(Bitly::API::Client) }
+    let(:organization) { instance_double(Bitly::API::Organization) }
     let(:group) { Bitly::API::Group.new(data: group_data, client: client) }
 
     it "can fetch its organization" do
@@ -90,7 +90,7 @@ RSpec.describe Bitly::API::Group do
     end
 
     it "fetches its preferences, only once" do
-      preferences = double("preferences")
+      preferences = instance_double(Bitly::API::Group::Preferences)
       expect(Bitly::API::Group::Preferences).to receive(:fetch).once
         .with(client: client, group_guid: "def456")
         .and_return(preferences)
@@ -140,11 +140,11 @@ RSpec.describe Bitly::API::Group do
     end
 
     it "refetches the organization after updating the organization guid" do
-      organization1 = double("organization1")
+      organization1 = instance_double(Bitly::API::Organization)
       expect(Bitly::API::Organization).to receive(:fetch).once
         .with(client: client, organization_guid: "abc123")
         .and_return(organization1)
-      organization2 = double("organization2")
+      organization2 = instance_double(Bitly::API::Organization)
       expect(Bitly::API::Organization).to receive(:fetch).once
         .with(client: client, organization_guid: "ghi789")
         .and_return(organization2)
@@ -181,7 +181,7 @@ RSpec.describe Bitly::API::Group do
     end
 
     it "can get shorten counts" do
-      shorten_counts_mock = double("shorten_counts")
+      shorten_counts_mock = instance_double(Bitly::API::ShortenCounts)
       expect(Bitly::API::ShortenCounts).to receive(:by_group)
         .with(client: client, group_guid: group.guid)
         .and_return(shorten_counts_mock)
@@ -190,7 +190,7 @@ RSpec.describe Bitly::API::Group do
     end
 
     it "can get bitlinks" do
-      bitlinks_mock = double("bitlinks")
+      bitlinks_mock = instance_double(Bitly::API::Bitlink)
       expect(Bitly::API::Bitlink).to receive(:list)
         .with(client: client, group_guid: group.guid)
         .and_return(bitlinks_mock)
@@ -199,7 +199,7 @@ RSpec.describe Bitly::API::Group do
     end
 
     it "can get referring networks metrics" do
-      click_metrics = double("referring_networks")
+      click_metrics = instance_double(Bitly::API::ClickMetric::List)
       expect(Bitly::API::ClickMetric).to receive(:list_referring_networks)
         .with(
           client: client,
@@ -214,7 +214,7 @@ RSpec.describe Bitly::API::Group do
     end
 
     it "can get country metrics" do
-      click_metrics = double("countries")
+      click_metrics = instance_double(Bitly::API::ClickMetric::List)
       expect(Bitly::API::ClickMetric).to receive(:list_countries_by_group)
         .with(
           client: client,

--- a/spec/bitly/api/oauth_app_spec.rb
+++ b/spec/bitly/api/oauth_app_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Bitly::API::OAuthApp do
       body: oauth_app_data.to_json,
       headers: {}
     )
-    client = double("client")
+    client = instance_double(Bitly::API::Client)
     expect(client).to receive(:request)
       .with(path: "/apps/jkl123")
       .and_return(response)

--- a/spec/bitly/api/organization_spec.rb
+++ b/spec/bitly/api/organization_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Bitly::API::Organization do
       body: { "organizations" => [organization_data] }.to_json,
       headers: {}
     )
-    client = double("client")
+    client = instance_double(Bitly::API::Client)
     expect(client).to receive(:request).with(path: "/organizations").and_return(response)
 
     organizations = Bitly::API::Organization.list(client: client)
@@ -40,7 +40,7 @@ RSpec.describe Bitly::API::Organization do
       body: organization_data.to_json,
       headers: {}
     )
-    client = double("client")
+    client = instance_double(Bitly::API::Client)
     expect(client).to receive(:request).with(path: "/organizations/abc123").and_return(response)
     organization = Bitly::API::Organization.fetch(client: client, organization_guid: "abc123")
     expect(organization.tier).to eq("free")
@@ -48,8 +48,8 @@ RSpec.describe Bitly::API::Organization do
   end
 
   describe "with an organization" do
-    let(:client) { double("client") }
-    let(:groups) { double("groups") }
+    let(:client) { instance_double(Bitly::API::Client) }
+    let(:groups) { instance_double(Bitly::API::Group::List) }
     let(:organization) { Bitly::API::Organization.new(data: organization_data, client: client) }
 
     it "can fetch groups filtered by guid" do
@@ -68,7 +68,7 @@ RSpec.describe Bitly::API::Organization do
     end
 
     it "can get shorten counts" do
-      shorten_counts_mock = double("shorten_counts")
+      shorten_counts_mock = instance_double(Bitly::API::ShortenCounts)
       expect(Bitly::API::ShortenCounts).to receive(:by_organization)
         .with(client: client, organization_guid: organization.guid)
         .and_return(shorten_counts_mock)

--- a/spec/bitly/api/shorten_counts_spec.rb
+++ b/spec/bitly/api/shorten_counts_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Bitly::API::ShortenCounts do
       "facet"=>"shorten_counts"
     }
   }
-  let(:client) { double("client") }
+  let(:client) { instance_double(Bitly::API::Client) }
 
   it "fetches data by organization" do
     response = Bitly::HTTP::Response.new(

--- a/spec/bitly/api/user_spec.rb
+++ b/spec/bitly/api/user_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Bitly::API::User do
       "default_group_guid"=>"def456"
     }
   }
-  let(:client) { double("client") }
+  let(:client) { instance_double(Bitly::API::Client) }
 
   it "fetches the authorized user with an API client" do
     response = Bitly::HTTP::Response.new(
@@ -47,7 +47,7 @@ RSpec.describe Bitly::API::User do
     end
 
     it "fetches the default group from the API" do
-      group = double("group")
+      group = instance_double(Bitly::API::Group)
       expect(Bitly::API::Group).to receive(:fetch).once
         .with(client: client, guid: "def456")
         .and_return(group)
@@ -73,11 +73,11 @@ RSpec.describe Bitly::API::User do
     end
 
     it "can update the default group guid" do
-      group1 = double("group")
+      group1 = instance_double(Bitly::API::Group)
       expect(Bitly::API::Group).to receive(:fetch).once
         .with(client: client, guid: "def456")
         .and_return(group1)
-      group2 = double("group")
+      group2 = instance_double(Bitly::API::Group)
       expect(Bitly::API::Group).to receive(:fetch).once
         .with(client: client, guid: "ghi789")
         .and_return(group2)

--- a/spec/bitly/http/client_spec.rb
+++ b/spec/bitly/http/client_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Bitly::HTTP::Client do
   describe "#request" do
     it "returns a Bitly::HTTP::Response if the request is made successfully" do
       request = Bitly::HTTP::Request.new(uri: URI.parse("https://bitly.com"))
-      adapter = double(:adapter)
+      adapter = instance_double(Bitly::HTTP::Adapters::NetHTTP)
       response_values = ["200", { response: "OK" }.to_json, {}, true]
       expect(adapter).to receive(:request).once.with(request).and_return(response_values)
       client = Bitly::HTTP::Client.new(adapter)
@@ -33,7 +33,7 @@ RSpec.describe Bitly::HTTP::Client do
 
     it "raises a Bitly::Error if the request is not successful" do
       request = Bitly::HTTP::Request.new(uri: URI.parse("https://bitly.com"))
-      adapter = double(:adapter)
+      adapter = instance_double(Bitly::HTTP::Adapters::NetHTTP)
       response_values = ["500", { response: "Not OK" }.to_json, {}, false]
       expect(adapter).to receive(:request).once.with(request).and_return(response_values)
       client = Bitly::HTTP::Client.new(adapter)


### PR DESCRIPTION
This let's Rspec do some more checking that the methods can actually be called. Wish I'd known about this sooner.